### PR TITLE
Reduce workflow run time and allow major version config

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -24,7 +24,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR and enable auto-merge
         # Explicitly opt into major version updates.
-        if: ${{ steps.dependabot-metadata.outputs.update-type != "version-update:semver-major" || inputs.ALLOW_MAJOR == true }}
+        if: steps.dependabot-metadata.outputs.update-type != "version-update:semver-major"
         # Run these concurrently to save execution time
         run: gh pr review --approve "$PR_URL" & gh pr merge --auto --squash "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -18,13 +18,9 @@ jobs:
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ inputs.PR_URL}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: Approve PR and enable auto-merge
+        # Run these concurrently to save execution time
+        run: gh pr review --approve "$PR_URL" & gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ inputs.PR_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -7,6 +7,10 @@ on:
       PR_URL:
         required: true
         type: string
+      ALLOW_MAJOR:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   approve-dependabot:
@@ -19,6 +23,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR and enable auto-merge
+        # Explicitly opt into major version updates.
+        if: ${{ steps.dependabot-metadata.outputs.update-type != "version-update:semver-major" || inputs.ALLOW_MAJOR == true }}
         # Run these concurrently to save execution time
         run: gh pr review --approve "$PR_URL" & gh pr merge --auto --squash "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -24,7 +24,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR and enable auto-merge
         # Explicitly opt into major version updates.
-        if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
+        if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' || inputs.ALLOW_MAJOR == true
         # Run these concurrently to save execution time
         run: gh pr review --approve "$PR_URL" & gh pr merge --auto --squash "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -24,7 +24,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR and enable auto-merge
         # Explicitly opt into major version updates.
-        if: steps.dependabot-metadata.outputs.update-type != "version-update:semver-major"
+        if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
         # Run these concurrently to save execution time
         run: gh pr review --approve "$PR_URL" & gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
https://forto.atlassian.net/browse/CFTB-1213

- Reduce the time the workflow needs to run by up to 20% by approving and auto-merging in parallel.
- Explicitly opt into major version updates, because they sometimes contain breaking changes that need manual inspection (e.g. changing a command line argument for running a script, etc.)
