### PR TITLE
Delegate PubSub creation to services

### DIFF
--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -40,9 +40,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           install_components: 'beta,pubsub-emulator'
-      - name: 'Start Pub/Sub emulator'
-        run: |
-          gcloud beta emulators pubsub start --project test-project --host-port 0.0.0.0:8085 &
       - name: Install AWS CLI v2
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip


### PR DESCRIPTION
Instead of running the gcloud command and creating pubsub immediately in the workflow, we should delegate the user who wants to create what they want. 