### PR TITLE
Allow local stack image tag to be passed from consumers

### DIFF
--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -40,9 +40,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           install_components: 'beta,pubsub-emulator'
-      - name: 'Start Pub/Sub emulator'
-        run: |
-          gcloud beta emulators pubsub start --project test-project --host-port 0.0.0.0:8085 &
       - name: Install AWS CLI v2
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip

--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -6,7 +6,7 @@ on:
       VERDACCIO_FORTO_IO_TOKEN:
         required: true
     inputs:
-      LOCALSTACK_VERSION:
+      LOCALSTACK_IMAGE_TAG:
         description: 'Localstack version to use'
         required: false
         type: string
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       localstack:
-        image: localstack/localstack:${{ inputs.LOCALSTACK_VERSION }}
+        image: localstack/localstack:${{ inputs.LOCALSTACK_IMAGE_TAG }}
         ports:
           - 4566-4597:4566-4597
         env:

--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -5,6 +5,12 @@ on:
     secrets:
       VERDACCIO_FORTO_IO_TOKEN:
         required: true
+    inputs:
+      LOCALSTACK_VERSION:
+        description: 'Localstack version to use'
+        required: false
+        type: string
+        default: 'latest'
 
 env:
   VERDACCIO_FORTO_IO_TOKEN: ${{ secrets.VERDACCIO_FORTO_IO_TOKEN }}
@@ -15,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack:${{ inputs.LOCALSTACK_VERSION }}
         ports:
           - 4566-4597:4566-4597
         env:

--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -46,6 +46,9 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           install_components: 'beta,pubsub-emulator'
+      - name: 'Start Pub/Sub emulator'
+        run: |
+          gcloud beta emulators pubsub start --project test-project --host-port 0.0.0.0:8085 &
       - name: Install AWS CLI v2
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip


### PR DESCRIPTION
# Context
With the latest version of the local stack image, we start getting the Unknown attribute `FIFOQueue`
![image](https://github.com/freight-hub/gh-workflows/assets/3200267/5f1ae684-1913-468a-b431-e915d324c01d)

The PR aims to add functionality so that workflow consumers can pass the desired version for their usage.

IMO: It is also better to stick with a version instead of trying to use latest all the time, which causes issues as in the example above. 

# JIRA TICKET
https://forto.atlassian.net/browse/BRO-2239