### PR TITLE
Upgrades OpenAPI spec workflow to node 20

### DIFF
--- a/.github/workflows/build-open-api-spec.yml
+++ b/.github/workflows/build-open-api-spec.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.token }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn build


### PR DESCRIPTION
Pull #11 didn't update the node version for the open api spec builder to the currently active LTS release of node, our pipelines are failing because peer dependencies were updated to expect at least node >= 20. [See here](https://github.com/freight-hub/customer-master-data/actions/runs/9854902535/job/27208683690?pr=2361).

MD-2394