### PR TITLE
Fix invalid npm publish usage

### DIFF
--- a/.github/workflows/package-build-check-publish.yml
+++ b/.github/workflows/package-build-check-publish.yml
@@ -65,7 +65,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn version --new-version ${{ steps.tag.outputs.pre_release_version }} --no-git-tag-version
-      - run: npm publish --tag ${{ steps.tag.outputs.pre_release_version }}
+      - run: npm publish ${{ steps.tag.outputs.pre_release_version }}
       - name: Publish to npm
         if: ${{ inputs.publish-to-gar }}
         run: |


### PR DESCRIPTION
Using --tag 1.0.0 results in the error `npm error Tag name must not be a valid SemVer range: 4.1.0-alpha.38`. This fixes it by removing the tag and publishing as a pre-release version.

See https://github.com/freight-hub/nestjs-open-api/actions/runs/10959472536/job/30431922294?pr=9

AT-83