### PR TITLE
Alter gcloud auth to not write credentials file

### DIFF
--- a/.github/workflows/build-open-api-spec.yml
+++ b/.github/workflows/build-open-api-spec.yml
@@ -29,14 +29,16 @@ jobs:
         with:
           token: ${{ secrets.token }}
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/node-build-lint-test.yml
+++ b/.github/workflows/node-build-lint-test.yml
@@ -16,14 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/node-localstack-build-lint-test.yml
+++ b/.github/workflows/node-localstack-build-lint-test.yml
@@ -25,14 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -34,14 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/node-mongo-build-lint-test.yml
+++ b/.github/workflows/node-mongo-build-lint-test.yml
@@ -31,14 +31,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/package-build-check-publish.yml
+++ b/.github/workflows/package-build-check-publish.yml
@@ -36,14 +36,16 @@ jobs:
         with:
           token: ${{ secrets.token }}
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20
@@ -70,7 +72,6 @@ jobs:
         if: ${{ inputs.publish-to-gar }}
         run: |
           rm -f ~/.npmrc .npmrc .yarnrc
-          echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
           echo "//europe-west1-npm.pkg.dev/forto-artifacts/${{ inputs.gar-registry }}/:_authToken=${FORTO_ARTIFACTS_TOKEN}" >> .npmrc
           yarn publish --registry https://europe-west1-npm.pkg.dev/forto-artifacts/${{ inputs.gar-registry }}/ --tag canary
       - if: ${{ !inputs.publish-to-gar }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -34,14 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 'Authenticate to Google Cloud'
-        id: 'auth'
+        id: 'gcloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/630000710192/locations/global/workloadIdentityPools/github/providers/actions-token
           service_account: ${{ inputs.service_account }}
+          token_format: access_token
           access_token_lifetime: '600s'
-      - name: 'Update .npmrc with new token'
-        run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
+          create_credentials_file: false
+      - name: 'Export FORTO_ARTIFACTS_TOKEN variable'
+        run: echo "FORTO_ARTIFACTS_TOKEN=${{ steps.gcloud.outputs.access_token }}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: 20
@@ -52,7 +54,6 @@ jobs:
         if: ${{ inputs.publish-to-gar }}
         run: |
           rm -f ~/.npmrc .npmrc .yarnrc
-          echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
           echo "//europe-west1-npm.pkg.dev/forto-artifacts/${{ inputs.gar-registry }}/:_authToken=${FORTO_ARTIFACTS_TOKEN}" >> .npmrc
           yarn publish --registry https://europe-west1-npm.pkg.dev/forto-artifacts/${{ inputs.gar-registry }}/
       - if: ${{ !inputs.publish-to-gar }}
@@ -75,4 +76,3 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_PACKAGE_WEBHOOK_URL }}
           message: ${{ steps.package-info.outputs.name }}:${{ steps.package-info.outputs.version }} was released!
           is_markdown: false
-


### PR DESCRIPTION
Some pipelines have resulted in adding this file to git:

![image](https://github.com/user-attachments/assets/647fabdb-6929-43b6-ab3a-407ee15aad19)

We can avoid creating the file by plumbing the token thru Github Actions outputs instead.