### PR TITLE
Update several outdated github actions

### DIFF
--- a/.github/workflows/build-open-api-spec.yml
+++ b/.github/workflows/build-open-api-spec.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build Open API specification
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.token }}
       - name: 'Authenticate to Google Cloud'
@@ -37,7 +37,7 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/node-build-lint-test.yml
+++ b/.github/workflows/node-build-lint-test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build - Lint Check - Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -24,7 +24,7 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/node-localstack-build-lint-test.yml
+++ b/.github/workflows/node-localstack-build-lint-test.yml
@@ -23,7 +23,7 @@ jobs:
           EDGE_PORT: 4566
           SERVICES: sqs,sns
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -33,7 +33,7 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/node-localstack-pubsub-build-lint-test.yml
+++ b/.github/workflows/node-localstack-pubsub-build-lint-test.yml
@@ -32,7 +32,7 @@ jobs:
         ports:
           - "8085:8085"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -42,7 +42,7 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/node-mongo-build-lint-test.yml
+++ b/.github/workflows/node-mongo-build-lint-test.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 5
           --name mongo
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -39,7 +39,7 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/package-build-check-publish.yml
+++ b/.github/workflows/package-build-check-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       VERDACCIO_FORTO_IO_TOKEN:
-        required: true
+        required: false
       token:
         required: true
     inputs:
@@ -32,7 +32,7 @@ jobs:
     name: Publish pre-release version
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.token }}
       - name: 'Authenticate to Google Cloud'
@@ -44,13 +44,13 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
       - name: bump-version-from-tag
         id: tag
-        uses: freight-hub/action-tag-bump-version@v1.3
+        uses: freight-hub/action-tag-bump-version@v1.4
         with:
           build_number: ${{ github.run_number }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -20,7 +20,7 @@ on:
         type: string
     secrets:
       VERDACCIO_FORTO_IO_TOKEN:
-        required: true
+        required: false
       SLACK_PACKAGE_WEBHOOK_URL:
         required: true
 
@@ -32,7 +32,7 @@ jobs:
     name: Publish main version
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -42,7 +42,7 @@ jobs:
           access_token_lifetime: '600s'
       - name: 'Update .npmrc with new token'
         run: echo "FORTO_ARTIFACTS_TOKEN=$(gcloud auth print-access-token)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
@@ -75,4 +75,3 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_PACKAGE_WEBHOOK_URL }}
           message: ${{ steps.package-info.outputs.name }}:${{ steps.package-info.outputs.version }} was released!
           is_markdown: false
-


### PR DESCRIPTION
These updates are largely tied to EOL nodejs.

Also includes fixing the `pacakge.json` typo in the PR comments. (via update)

Also marks the Verdaccio secrets as optional.